### PR TITLE
✨ tag 공통 컴포넌트 추가

### DIFF
--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -1,0 +1,9 @@
+import * as S from './styled';
+
+type Props = {
+  content: string;
+};
+
+export default function Tag({ content }: Props) {
+  return <S.TagWrapper>{content}</S.TagWrapper>;
+}

--- a/src/components/common/Tag/styled.ts
+++ b/src/components/common/Tag/styled.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+import { Caption1 } from '@/src/styles/commons';
+
+export const TagWrapper = styled.span`
+  padding: 4px 12px;
+  background: #f0f2f7;
+  color: #989fb3;
+  border-radius: 14px;
+  line-height: 14px;
+
+  ${Caption1}
+`;


### PR DESCRIPTION
### 📃 변경사항

- #13 
- tag 공통 컴포넌트 추가 했습니다

### 📌 중점적으로 볼 부분

- 폴더 이름은 파스칼 케이스로, 내부 파일은 index.tsx 와 styled.ts 로 작성했습니다
- import 할 때 `import * as S from './styled';` 로 하는 이유는
사용할때 실제 컴포넌트 인지 스타일 컴포넌트 인지 구분하기 위해서 입니다
- 색상 팔레트가 아직 없어서 일단 색상 코드를 그대로 넣었습니다
- props 의 타입은 모든 컴포넌트에서 `type Props = {}` 로 통일합니다
- 컴포넌트는 아래와 같은 형태로 작성하는 편입니다
```js
export default function Component({  }: Props) {
  return //...;
}
```

### 💫 기타사항

- 저는 이렇게 작성해왔는데 다른 의견 있으시면 모두 편하게 말씀 부탁드립니다!
여기서 정하고 가면 좋을 것 같아요!

### ✔ 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
