### PR TITLE
BottomButton 공통 컴포넌트 추가

### DIFF
--- a/src/components/common/Buttons/BottomButton/index.tsx
+++ b/src/components/common/Buttons/BottomButton/index.tsx
@@ -1,0 +1,21 @@
+import { ButtonHTMLAttributes } from 'react';
+import * as S from './styled';
+
+type Props = {
+  name: string;
+  isRound?: boolean;
+  isDark?: boolean;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export default function BottomButton({
+  name,
+  isRound = false,
+  isDark = false,
+  ...args
+}: Props) {
+  return (
+    <S.BottomButtonWrapper isDark={isDark} isRound={isRound} {...args}>
+      {name}
+    </S.BottomButtonWrapper>
+  );
+}

--- a/src/components/common/Buttons/BottomButton/styled.ts
+++ b/src/components/common/Buttons/BottomButton/styled.ts
@@ -1,0 +1,26 @@
+import { Body3 } from '@/src/styles/commons';
+import styled from '@emotion/styled';
+
+export const BottomButtonWrapper = styled.button<{
+  isRound: boolean;
+  isDark: boolean;
+}>`
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  padding: ${({ isRound }) => (isRound ? '14px' : '16px')} 0;
+  border-radius: ${({ isRound }) => (isRound ? '12px' : '30px')};
+  text-align: center;
+  line-height: 21px;
+  background-color: ${({ isDark, theme: { colors } }) =>
+    isDark ? '#767C8D' : colors.white};
+  color: ${({ isDark, theme: { colors } }) =>
+    isDark ? colors.white : '#767C8D'};
+
+  ${Body3}
+
+  &:disabled {
+    background-color: #e4e7ef;
+    color: ${({ theme: { colors } }) => colors.white};
+  }
+`;


### PR DESCRIPTION
### 📎 이슈번호

- #13 

### 📃 변경사항

- `BottomButton` 공통 컴포넌트 추가

### 📌 중점적으로 볼 부분

- `isDark` prop 에 따라 배경 색상이 바뀝니다
- `isRound` prop 에 따라 border-radius 와 패딩이 바뀝니다
- `position : fixed` 를 통해 화면 바닥에 고정됩니다

### 🎇 스크린샷

<img width="582" alt="스크린샷 2022-11-19 오후 4 51 39" src="https://user-images.githubusercontent.com/68256639/202840845-2010f405-d409-4207-97c4-a8d6d1106211.png">

### ✔ 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
