### PR TITLE
✨ select 컴포넌트 추가

### DIFF
--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -6,12 +6,12 @@ interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
   placeholder?: string;
 }
 
-export default function Select({ options, placeholder, ...props }: Props) {
+export default function Select({ options, placeholder = "", ...props }: Props) {
   const optionKeys = Object.keys(options);
   return (
     <S.Select {...props}>
       <S.Item selected disabled value={undefined}>
-        {placeholder ?? ""}
+        {placeholder}
       </S.Item>
       {optionKeys.map((key) => (
         <S.Item key={key} value={key}>

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -1,0 +1,23 @@
+import * as S from "./styled";
+import type { SelectHTMLAttributes } from "react";
+
+interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
+  options: { [key: string]: string };
+  placeholder?: string;
+}
+
+export default function Select({ options, placeholder, ...props }: Props) {
+  const optionKeys = Object.keys(options);
+  return (
+    <S.Select {...props}>
+      <S.Item selected disabled value={undefined}>
+        {placeholder ?? ""}
+      </S.Item>
+      {optionKeys.map((key) => (
+        <S.Item key={key} value={key}>
+          {options[key]}
+        </S.Item>
+      ))}
+    </S.Select>
+  );
+}

--- a/src/components/common/Select/styled.ts
+++ b/src/components/common/Select/styled.ts
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+export const Select = styled.select`
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 20px;
+  padding-right: 36px;
+  border-radius: 8px;
+  border-color: #e4e7ef;
+
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMiIgaGVpZ2h0PSIyMiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBmaWxsPSIjQTRBOUI4IiBkPSJtNS44OTUgOC41NS0uNDM3LS4zOTYtLjc5Ljg3NC40MzcuMzk1Ljc5LS44NzRabTUuMzA4IDUuNTkzLS4zOTUuNDM3LjM5NS4zNTcuMzk1LS4zNTctLjM5NS0uNDM3Wk0xNy42OCA5LjA4bC40MzctLjM5NS0uNzktLjg3NC0uNDM4LjM5NS43OS44NzRabS0xMi41NzYuMzQzIDUuNzAzIDUuMTU3Ljc5LS44NzQtNS43MDMtNS4xNTctLjc5Ljg3NFptNi40OTMgNS4xNTcgNi4wODMtNS41LS43OS0uODc0LTYuMDgzIDUuNS43OS44NzRaIi8+Cjwvc3ZnPgo=");
+  background-size: 20px;
+  background-repeat: no-repeat;
+  background-position: calc(100% - 8px) center;
+
+  color: ${({ value }) => (value ? "#767c8d" : "#bcc1d0")};
+
+  option[disabled] {
+    display: none;
+  }
+`;
+export const Item = styled.option``;

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import Select from "@/src/components/common/Select";
+
+export default {
+  title: "Components/Select",
+  component: Select,
+} as ComponentMeta<typeof Select>;
+
+const Template: ComponentStory<typeof Select> = (args) => {
+  const [value, setValue] = useState<string>();
+  return (
+    <Select
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      {...args}
+    />
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  placeholder: "Select Component PlaceHolder",
+  options: {
+    optionA: "valueA",
+    optionB: "valueB",
+    optionC: "valueC",
+    optionD: "valueD",
+  },
+};


### PR DESCRIPTION
### 📎 이슈번호
#17

### 📃 변경사항

- Select 공통 컴포넌트 추가

### 📌 중점적으로 볼 부분

- 오른쪽 화살표 부분이 select에 padding을 적용했을 때 위치가 이상해서 피그마에 있는 화살표를 base64 인코딩하여 이미지로 사용 하였습니다.
- placeholder 기능을 추가 하였습니다.
- option에 대한 값들은 `options`라는 props으로 object 형태로 넘겨주면 자동으로 생성 됩니다. 형식은 아래와 같습니다.
```javascript
// key는 option의 실제 값
// value는 option의 표시 값 입니다.
const options = {
  key: value
}
```
- storybook 명령어를 통해 쉽게 확인 가능합니다.
### 🎇 스크린샷

<img width="287" alt="image" src="https://user-images.githubusercontent.com/16554536/205108615-ac271482-b30b-4fdc-80f2-94cf79d78f59.png">
<img width="342" alt="image" src="https://user-images.githubusercontent.com/16554536/205227704-bd7c6455-ee0b-4350-adc4-031d322fc486.png">


### ✔ 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
