### PR TITLE
✨ Input 스타일 및 Clear 버튼 추가

### DIFF
--- a/src/components/common/Input/InputClear.tsx
+++ b/src/components/common/Input/InputClear.tsx
@@ -1,23 +1,25 @@
-import React, { useRef } from "react";
+import React, { useState } from "react";
 import * as S from "./styled";
 import { InputDefault } from "./InputDefault";
 
+import type { Dispatch, SetStateAction } from "react";
 import type { InputDefaultProps } from "./InputDefault";
 
-export function InputClear(props: Omit<InputDefaultProps, "tail">) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const onClear = () => {
-    inputRef.current!.value = "";
+interface Props extends Omit<InputDefaultProps, "tail"> {
+  onClear: Dispatch<SetStateAction<unknown>>;
+}
+
+export function InputClear({ onClear, ...props }: Props) {
+  const onClearAction = () => {
+    onClear("");
   };
 
   return (
     <InputDefault
-      ref={inputRef}
       tail={
-        <S.Clear
-          onClick={onClear}
-          src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDE1IDE2Ij4KICA8cGF0aCBmaWxsPSIjQkNDMUQwIiBkPSJtMTQuMTY3IDMuMDk2LjcxMS0uNzAzTDEzLjQ3My45N2wtLjcxMi43MDMgMS40MDYgMS40MjNaTTEuMzQgMTIuOTU2bC0uNzEyLjcwMiAxLjQwNiAxLjQyMy43MTEtLjcwMy0xLjQwNS0xLjQyM1pNMTIuNzYgMS42NzIgMS4zNCAxMi45NTVsMS40MDUgMS40MjNMMTQuMTY3IDMuMDk2IDEyLjc2IDEuNjczWiIvPgogIDxwYXRoIGZpbGw9IiNCQ0MxRDAiIGQ9Im0xMi43NjEgMTQuMzc4LjcxMi43MDMgMS40MDUtMS40MjMtLjcxMS0uNzAzLTEuNDA2IDEuNDIzWk0yLjc0NSAxLjY3MyAyLjAzNC45Ny42MjggMi4zOTNsLjcxMi43MDMgMS40MDUtMS40MjNabTExLjQyMiAxMS4yODJMMi43NDUgMS42NzMgMS4zNCAzLjA5NmwxMS40MiAxMS4yODIgMS40MDYtMS40MjNaIi8+Cjwvc3ZnPgo="
-        />
+        <button type="button" onClick={onClearAction}>
+          <S.Clear src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDE1IDE2Ij4KICA8cGF0aCBmaWxsPSIjQkNDMUQwIiBkPSJtMTQuMTY3IDMuMDk2LjcxMS0uNzAzTDEzLjQ3My45N2wtLjcxMi43MDMgMS40MDYgMS40MjNaTTEuMzQgMTIuOTU2bC0uNzEyLjcwMiAxLjQwNiAxLjQyMy43MTEtLjcwMy0xLjQwNS0xLjQyM1pNMTIuNzYgMS42NzIgMS4zNCAxMi45NTVsMS40MDUgMS40MjNMMTQuMTY3IDMuMDk2IDEyLjc2IDEuNjczWiIvPgogIDxwYXRoIGZpbGw9IiNCQ0MxRDAiIGQ9Im0xMi43NjEgMTQuMzc4LjcxMi43MDMgMS40MDUtMS40MjMtLjcxMS0uNzAzLTEuNDA2IDEuNDIzWk0yLjc0NSAxLjY3MyAyLjAzNC45Ny42MjggMi4zOTNsLjcxMi43MDMgMS40MDUtMS40MjNabTExLjQyMiAxMS4yODJMMi43NDUgMS42NzMgMS4zNCAzLjA5NmwxMS40MiAxMS4yODIgMS40MDYtMS40MjNaIi8+Cjwvc3ZnPgo=" />
+        </button>
       }
       {...props}
     />

--- a/src/components/common/Input/InputClear.tsx
+++ b/src/components/common/Input/InputClear.tsx
@@ -6,20 +6,16 @@ import type { Dispatch, SetStateAction } from "react";
 import type { InputDefaultProps } from "./InputDefault";
 
 interface Props extends Omit<InputDefaultProps, "tail"> {
-  onClear: Dispatch<SetStateAction<unknown>>;
+  onClear: () => void;
 }
 
 export function InputClear({ onClear, ...props }: Props) {
-  const onClearAction = () => {
-    onClear("");
-  };
-
   return (
     <InputDefault
       tail={
-        <button type="button" onClick={onClearAction}>
-          <S.Clear src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDE1IDE2Ij4KICA8cGF0aCBmaWxsPSIjQkNDMUQwIiBkPSJtMTQuMTY3IDMuMDk2LjcxMS0uNzAzTDEzLjQ3My45N2wtLjcxMi43MDMgMS40MDYgMS40MjNaTTEuMzQgMTIuOTU2bC0uNzEyLjcwMiAxLjQwNiAxLjQyMy43MTEtLjcwMy0xLjQwNS0xLjQyM1pNMTIuNzYgMS42NzIgMS4zNCAxMi45NTVsMS40MDUgMS40MjNMMTQuMTY3IDMuMDk2IDEyLjc2IDEuNjczWiIvPgogIDxwYXRoIGZpbGw9IiNCQ0MxRDAiIGQ9Im0xMi43NjEgMTQuMzc4LjcxMi43MDMgMS40MDUtMS40MjMtLjcxMS0uNzAzLTEuNDA2IDEuNDIzWk0yLjc0NSAxLjY3MyAyLjAzNC45Ny42MjggMi4zOTNsLjcxMi43MDMgMS40MDUtMS40MjNabTExLjQyMiAxMS4yODJMMi43NDUgMS42NzMgMS4zNCAzLjA5NmwxMS40MiAxMS4yODIgMS40MDYtMS40MjNaIi8+Cjwvc3ZnPgo=" />
-        </button>
+        <S.ClearButton type="button" onClick={() => onClear()}>
+          <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDE1IDE2Ij4KICA8cGF0aCBmaWxsPSIjQkNDMUQwIiBkPSJtMTQuMTY3IDMuMDk2LjcxMS0uNzAzTDEzLjQ3My45N2wtLjcxMi43MDMgMS40MDYgMS40MjNaTTEuMzQgMTIuOTU2bC0uNzEyLjcwMiAxLjQwNiAxLjQyMy43MTEtLjcwMy0xLjQwNS0xLjQyM1pNMTIuNzYgMS42NzIgMS4zNCAxMi45NTVsMS40MDUgMS40MjNMMTQuMTY3IDMuMDk2IDEyLjc2IDEuNjczWiIvPgogIDxwYXRoIGZpbGw9IiNCQ0MxRDAiIGQ9Im0xMi43NjEgMTQuMzc4LjcxMi43MDMgMS40MDUtMS40MjMtLjcxMS0uNzAzLTEuNDA2IDEuNDIzWk0yLjc0NSAxLjY3MyAyLjAzNC45Ny42MjggMi4zOTNsLjcxMi43MDMgMS40MDUtMS40MjNabTExLjQyMiAxMS4yODJMMi43NDUgMS42NzMgMS4zNCAzLjA5NmwxMS40MiAxMS4yODIgMS40MDYtMS40MjNaIi8+Cjwvc3ZnPgo=" />
+        </S.ClearButton>
       }
       {...props}
     />

--- a/src/components/common/Input/InputClear.tsx
+++ b/src/components/common/Input/InputClear.tsx
@@ -1,0 +1,25 @@
+import React, { useRef } from "react";
+import * as S from "./styled";
+import { InputDefault } from "./InputDefault";
+
+import type { InputDefaultProps } from "./InputDefault";
+
+export function InputClear(props: Omit<InputDefaultProps, "tail">) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onClear = () => {
+    inputRef.current!.value = "";
+  };
+
+  return (
+    <InputDefault
+      ref={inputRef}
+      tail={
+        <S.Clear
+          onClick={onClear}
+          src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDE1IDE2Ij4KICA8cGF0aCBmaWxsPSIjQkNDMUQwIiBkPSJtMTQuMTY3IDMuMDk2LjcxMS0uNzAzTDEzLjQ3My45N2wtLjcxMi43MDMgMS40MDYgMS40MjNaTTEuMzQgMTIuOTU2bC0uNzEyLjcwMiAxLjQwNiAxLjQyMy43MTEtLjcwMy0xLjQwNS0xLjQyM1pNMTIuNzYgMS42NzIgMS4zNCAxMi45NTVsMS40MDUgMS40MjNMMTQuMTY3IDMuMDk2IDEyLjc2IDEuNjczWiIvPgogIDxwYXRoIGZpbGw9IiNCQ0MxRDAiIGQ9Im0xMi43NjEgMTQuMzc4LjcxMi43MDMgMS40MDUtMS40MjMtLjcxMS0uNzAzLTEuNDA2IDEuNDIzWk0yLjc0NSAxLjY3MyAyLjAzNC45Ny42MjggMi4zOTNsLjcxMi43MDMgMS40MDUtMS40MjNabTExLjQyMiAxMS4yODJMMi43NDUgMS42NzMgMS4zNCAzLjA5NmwxMS40MiAxMS4yODIgMS40MDYtMS40MjNaIi8+Cjwvc3ZnPgo="
+        />
+      }
+      {...props}
+    />
+  );
+}

--- a/src/components/common/Input/InputDefault.tsx
+++ b/src/components/common/Input/InputDefault.tsx
@@ -20,6 +20,7 @@ export const InputDefault = React.forwardRef<
   return (
     <S.Wrap status={status} styleOption={inputStyle}>
       <S.Input
+        value={value}
         ref={ref}
         onFocus={() => setStatus("active")}
         onBlur={(e) => !e.target.value && setStatus("inactive")}

--- a/src/components/common/Input/InputDefault.tsx
+++ b/src/components/common/Input/InputDefault.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import * as S from "./styled";
+
+import type { InputHTMLAttributes } from "react";
+import type { Status, StyleOption } from "./styled";
+
+export interface InputDefaultProps
+  extends InputHTMLAttributes<HTMLInputElement> {
+  styleOption?: StyleOption;
+  tail?: React.ReactNode;
+}
+
+export const InputDefault = React.forwardRef<
+  HTMLInputElement,
+  InputDefaultProps
+>(({ value, styleOption, tail, ...props }, ref) => {
+  const [status, setStatus] = useState<Status>("inactive");
+  const inputStyle = styleOption ?? "underline";
+
+  return (
+    <S.Wrap status={status} styleOption={inputStyle}>
+      <S.Input
+        ref={ref}
+        onFocus={() => setStatus("active")}
+        onBlur={(e) => !e.target.value && setStatus("inactive")}
+        {...props}
+      />
+      {tail && tail}
+    </S.Wrap>
+  );
+});

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,26 +1,4 @@
-import { useState } from "react";
-import * as S from "./styled";
+import { InputDefault } from "./InputDefault";
 
-import type { InputStatus } from "./styled";
-import type { InputHTMLAttributes } from "react";
-
-interface Props extends InputHTMLAttributes<HTMLInputElement> {}
-
-/**
- * Active 조건
- * 1. 값이
- */
-export default function Input({ value, ...props }: Props) {
-  const [status, setStatus] = useState<InputStatus>("inactive");
-
-  return (
-    <S.Wrap>
-      <S.Input
-        status={status}
-        onFocus={() => setStatus("active")}
-        onBlur={(e) => !e.target.value && setStatus("inactive")}
-        {...props}
-      />
-    </S.Wrap>
-  );
-}
+export * from "./InputClear";
+export default InputDefault;

--- a/src/components/common/Input/styled.ts
+++ b/src/components/common/Input/styled.ts
@@ -20,7 +20,7 @@ const inputFill = css`
   background-color: #f0f2f6;
 `;
 
-export const Wrap = styled.label<InputStyleProps>`
+export const Wrap = styled.div<InputStyleProps>`
   display: flex;
   align-items: center;
   ${({ status, styleOption }) =>

--- a/src/components/common/Input/styled.ts
+++ b/src/components/common/Input/styled.ts
@@ -39,6 +39,8 @@ export const Input = styled.input`
   }
 `;
 
-export const Clear = styled.img`
+export const ClearButton = styled.button`
   cursor: pointer;
+  border: none;
+  background-color: transparent;
 `;

--- a/src/components/common/Input/styled.ts
+++ b/src/components/common/Input/styled.ts
@@ -1,39 +1,44 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-export type InputStatus = "inactive" | "active"; // Input 활성화 여부
+export type Status = "inactive" | "active"; // Input 활성화 여부
+export type StyleOption = "underline" | "fill"; // Input 스타일 옵션
 
 interface InputStyleProps {
-  status: InputStatus;
+  status: Status;
+  styleOption: StyleOption;
 }
 
-const statusStyle = {
-  inactive: css`
-    border-color: #e4e7ef;
-  `,
-  active: css`
-    border-color: #a4a9b8;
-  `,
-} as const;
-
-export const Wrap = styled.div`
-  height: inherit;
-`;
-export const Input = styled.input<InputStyleProps>`
-  color: #767c8d;
-
-  width: 100%;
-  height: inherit;
-  padding-bottom: 8px;
-  padding-left: 2px;
-
-  border: none;
+const inputUnderline = (status: Status) => css`
   border-bottom: 1px solid;
+  border-color: ${status === "active" ? "#a4a9b8" : "#e4e7ef"};
+  padding: 8px 2px;
+`;
+const inputFill = css`
+  padding: 12px;
+  border-radius: 8px;
+  background-color: #f0f2f6;
+`;
+
+export const Wrap = styled.label<InputStyleProps>`
+  display: flex;
+  align-items: center;
+  ${({ status, styleOption }) =>
+    styleOption === "underline" ? inputUnderline(status) : inputFill}
+`;
+export const Input = styled.input`
+  color: #767c8d;
+  border: none;
   outline: none;
+  width: 100%;
+  background-color: inherit;
+  border-radius: inherit;
 
   &::placeholder {
     color: #bcc1d0;
   }
+`;
 
-  ${({ status }) => statusStyle[status]}
+export const Clear = styled.img`
+  cursor: pointer;
 `;

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import Input from "@/src/components/common/Input";
+import Input, { InputClear } from "@/src/components/common/Input";
 
 export default {
   title: "Components/Input",
@@ -9,8 +9,15 @@ export default {
 } as ComponentMeta<typeof Input>;
 
 const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />;
+const TemplateClear: ComponentStory<typeof Input> = (args) => (
+  <InputClear {...args} />
+);
 
 export const Default = Template.bind({});
 Default.args = {
+  placeholder: "TextField",
+};
+export const Clear = TemplateClear.bind({});
+Clear.args = {
   placeholder: "TextField",
 };

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import Input, { InputClear } from "@/src/components/common/Input";
@@ -9,9 +9,17 @@ export default {
 } as ComponentMeta<typeof Input>;
 
 const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />;
-const TemplateClear: ComponentStory<typeof Input> = (args) => (
-  <InputClear {...args} />
-);
+const TemplateClear: ComponentStory<typeof Input> = (args) => {
+  const [value, setValue] = useState<string>("");
+  return (
+    <InputClear
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onClear={() => setValue("")}
+      {...args}
+    />
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {


### PR DESCRIPTION
### 📎 이슈번호

#51 
#32

### 📃 변경사항
- Input 스타일이 추가 되었습니다.
- X(clear) 버튼이 추가 되었습니다.

### 📌 중점적으로 볼 부분
- ref 접근을 위해 Input 컴포넌트에 `fowardRef`를 사용 하였습니다.
- props에 `tail`을 추가 하였습니다. tail에 `ReactNode`를 넘겨서 Input 맨 끝부분에 원하는 스타일을 추가 할 수 있습니다.
- Clear 버튼이 들어간 Input은 자주 사용할 것 같아 따로 만들어 두었습니다.

### 🎇 스크린샷
<img width="1243" alt="스크린샷 2022-12-05 오전 2 30 35" src="https://user-images.githubusercontent.com/16554536/205506099-7ba39ff1-5c30-456a-8531-86cfd1195306.png">

<img width="1240" alt="스크린샷 2022-12-05 오전 2 30 25" src="https://user-images.githubusercontent.com/16554536/205506118-1a4cc92c-1860-4dc2-b6a0-9367294dda9a.png">

### 💫 기타사항
- InputClear 컴포넌트에서 `X`표시가 언제 보이고 언제 안보이는지 정의가 안되있는 것 같아 항상 보이도록 해두었습니다. 
- X 표시는 base64 인코딩하여 바로 src로 사용하고 있습니다.
- Storybook에 모두 올려두었습니다. `storybook` 명령어를 통해 컴포넌트 확인 가능합니다!


### ✔ 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
