### PR TITLE
Fix/qa 2 (#127)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,9 @@ const nextConfig = {
     emotion: true,
   },
   images: {
-    domains: ["k.kakaocdn.net"],
+    domains: ["k.kakaocdn.net", "ggogeetbucket.s3.amazonaws.com"],
+    // dangerouslyAllowSVG: true,
+    // contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
   },
 };
 

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -43,7 +43,7 @@ export const usePostKakaoLoginMutate = () => {
       if (data.allowFriendsList) {
         return setToast({
           status: "success",
-          content: "로그인 성공",
+          content: "로그인에 성공했어요!",
         });
       } else {
         window.location.replace(getKakaoFriendsUri());
@@ -52,7 +52,7 @@ export const usePostKakaoLoginMutate = () => {
     onError: () =>
       setToast({
         status: "error",
-        content: "로그인에 문제가 발생하였습니다.",
+        content: "로그인에 실패했어요",
       }),
   });
 };

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -22,29 +22,31 @@ export default function Modal({
 }: Props) {
   return (
     <S.ModalWrapper>
-      {children ? (
-        children
-      ) : (
-        <S.ModalContent>
-          {title && <p>{title}</p>}
-          {description && <p>{description}</p>}
-          {buttons?.map(({ name, onClick }) => (
-            <S.ModalButton key={name} type="button" onClick={onClick}>
-              {name}
-            </S.ModalButton>
-          ))}
-        </S.ModalContent>
-      )}
-      {onClose && (
-        <S.ModalCloseButton type="button" onClick={onClose}>
-          <Image
-            src="/icons/icon__guideline-close--white.svg"
-            alt="웰컴 가이드 모달 닫기"
-            width={16}
-            height={16}
-          />
-        </S.ModalCloseButton>
-      )}
+      <S.ModalContainer>
+        {children ? (
+          children
+        ) : (
+          <S.ModalContent>
+            {title && <p>{title}</p>}
+            {description && <p>{description}</p>}
+            {buttons?.map(({ name, onClick }) => (
+              <S.ModalButton key={name} type="button" onClick={onClick}>
+                {name}
+              </S.ModalButton>
+            ))}
+          </S.ModalContent>
+        )}
+        {onClose && (
+          <S.ModalCloseButton type="button" onClick={onClose}>
+            <Image
+              src="/icons/icon__guideline-close--white.svg"
+              alt="웰컴 가이드 모달 닫기"
+              width={16}
+              height={16}
+            />
+          </S.ModalCloseButton>
+        )}
+      </S.ModalContainer>
     </S.ModalWrapper>
   );
 }

--- a/src/components/common/Modal/styled.ts
+++ b/src/components/common/Modal/styled.ts
@@ -1,10 +1,20 @@
 import styled from "@emotion/styled";
 import { Body2, Body4, Caption1 } from "@/src/styles/commons";
 
-export const ModalWrapper = styled.dialog`
+export const ModalWrapper = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  background-color: ${({ theme }) => theme.colors.navy70};
+  z-index: 40;
+`;
+
+export const ModalContainer = styled.dialog`
   display: block;
   margin: 0;
-  padding: 40px 20px 16px 20px;
+  padding: 40px 20px 28px 20px;
   border: none;
   width: 280px;
   position: fixed;
@@ -12,7 +22,7 @@ export const ModalWrapper = styled.dialog`
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 10000;
-  border-radius: 8px;
+  border-radius: 24px;
   background-color: ${({ theme: { colors } }) => colors.gray5};
 `;
 

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -25,7 +25,7 @@ export default function Tag({ color, label }: Props) {
       <div
         style={{
           backgroundColor: color,
-          padding: "4px 24px",
+          padding: "4px 8px",
           fontSize: "12px",
         }}
       >
@@ -52,5 +52,6 @@ export default function Tag({ color, label }: Props) {
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
+  gap: 2px;
   margin: "20px";
 `;

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import Image from "next/image";
 import { AnimatePresence } from "framer-motion";
 import * as S from "./styled";
@@ -11,6 +12,12 @@ export default function Toast() {
     if (icon === "success") return "/icons/icon__toast-success.svg";
     else return "/icons/icon__toast-error.svg";
   };
+
+  useEffect(() => {
+    if (currentToast) {
+      setTimeout(() => setToast(null), 3000);
+    }
+  }, [currentToast]);
 
   return (
     <S.Wrap>

--- a/src/components/common/Toast/styled.ts
+++ b/src/components/common/Toast/styled.ts
@@ -8,8 +8,10 @@ export const Wrap = styled.div`
   z-index: 999;
   left: 0;
   right: 0;
-  bottom: 10%;
+  bottom: 20px;
   width: 100%;
+  max-width: 430px;
+  margin: auto;
 
   display: flex;
   justify-content: center;
@@ -17,7 +19,8 @@ export const Wrap = styled.div`
 
 export const Container = styled(motion.button)`
   pointer-events: all;
-  width: 320px;
+  width: 100%;
+  margin: 20px;
 
   ${Body3}
   color: ${({ theme }) => theme.colors.white};

--- a/src/components/features/Home/WelcomeModal/index.tsx
+++ b/src/components/features/Home/WelcomeModal/index.tsx
@@ -9,30 +9,38 @@ const welcomeModalContents: {
   description: string;
   width: number;
   height: number;
+  image: string;
 }[] = [
   {
     description: "반가워요!\n꼬깃에 오신 것을 환영해요.",
+    image: "/gifs/ggogeet_welcome1.gif",
     width: 64,
     height: 64,
   },
   {
     description: "어떤 내용을 써야할지 망설여질 때\n꼬깃 가이드로 도와줄게요.",
+    image: "/gifs/ggogeet_welcome2.gif",
     width: 240,
     height: 155,
   },
   {
     description:
       "전하려는 마음을 메모해뒀다가\n잊지 않고 꼬깃을 보낼 수 있어요.",
+    image:
+      "https://ggogeetbucket.s3.amazonaws.com/gif/KakaoTalk_Photo_2023-01-12-22-12-05%20003.gif",
     width: 240,
     height: 155,
   },
   {
     description: "여기저기 흩어져 있던\n마음들을 차곡차곡 보관할 수 있어요.",
+    image:
+      "https://ggogeetbucket.s3.amazonaws.com/gif/KakaoTalk_Photo_2023-01-12-22-12-05%20004.gif",
     width: 240,
     height: 151,
   },
   {
     description: "꼬깃과 함께 편지를 써서\n소중한 마음을 주고받아볼까요?",
+    image: "/gifs/ggogeet_welcome5.gif",
     width: 186,
     height: 62,
   },

--- a/src/components/features/Home/WelcomeModal/styled.ts
+++ b/src/components/features/Home/WelcomeModal/styled.ts
@@ -34,6 +34,7 @@ export const SliderWrapper = styled.div`
     display: flex !important;
     justify-content: center;
     margin-top: 22px;
+
     li {
       width: 4px !important;
       height: 4px !important;

--- a/src/components/features/Home/index.tsx
+++ b/src/components/features/Home/index.tsx
@@ -50,6 +50,7 @@ const Home = () => {
             alt="꼬깃 홈 로고"
             width={224}
             height={48}
+            priority
           />
           <h1>
             혹시 전하고 싶었던 마음이 있나요?
@@ -64,6 +65,7 @@ const Home = () => {
               alt="꼬깃 보관함"
               width={220}
               height={149}
+              priority
             />
           </Link>
         </div>
@@ -74,6 +76,7 @@ const Home = () => {
               alt="꼬깃 메모"
               width={123}
               height={214}
+              priority
             />
           </Link>
         </div>
@@ -84,6 +87,7 @@ const Home = () => {
               alt="꼬깃 보내기"
               width={249}
               height={195}
+              priority
             />
           </Link>
         </div>
@@ -93,6 +97,7 @@ const Home = () => {
             alt="손글씨 - love ya"
             width={167}
             height={114}
+            priority
           />
         </div>
         <div className="home-get">
@@ -101,6 +106,7 @@ const Home = () => {
             alt="손글씨 - get to know"
             width={141}
             height={108}
+            priority
           />
         </div>
         <div className="home-thank">
@@ -109,6 +115,7 @@ const Home = () => {
             alt="손글씨 - thank you"
             width={166}
             height={91}
+            priority
           />
         </div>
         {/* <footer>

--- a/src/components/features/Home/styled.ts
+++ b/src/components/features/Home/styled.ts
@@ -42,7 +42,7 @@ const HomeWrapper = styled.div`
     z-index: 1;
   }
   .home-storage {
-    top: 226px;
+    top: 260px;
     left: 0;
   }
   .home-memo {
@@ -57,11 +57,11 @@ const HomeWrapper = styled.div`
     text-align: center;
   }
   .home-love {
-    top: 200px;
+    top: 240px;
     right: 0;
   }
   .home-get {
-    top: 368px;
+    top: 408px;
     left: 0;
   }
   .home-thank {

--- a/src/components/features/LetterWrite/Common/styled.ts
+++ b/src/components/features/LetterWrite/Common/styled.ts
@@ -121,7 +121,7 @@ const SituationTagWrapper = styled.div<{
       font-weight: 500;
       line-height: 150%;
       text-align: center;
-      letter-spacing: -0.005em;
+      /* letter-spacing: -0.005em; */
       font-size: ${({ stylesOptions }) =>
         stylesOptions?.fontSize ? `${stylesOptions.fontSize}px` : "12px"};
       color: ${({ color }) => color};

--- a/src/components/features/LetterWrite/InputRecipient/Forms/CompletedForm01.tsx
+++ b/src/components/features/LetterWrite/InputRecipient/Forms/CompletedForm01.tsx
@@ -56,7 +56,7 @@ const CompletedForm = ({ type }: CompletedFormProps) => {
       setIsCompletedProgressShow(true);
       setTimeout(() => {
         router.push("/letter-write?type=completed-02");
-      }, 3000);
+      }, 1500);
     } else {
       // TODO: 가은님) 외부 편지 저장하기 API + 꼬깃 보관함 이동하면서 토스트 메시지 추가
     }
@@ -137,7 +137,7 @@ const CompletedForm = ({ type }: CompletedFormProps) => {
                     <span>FROM</span>
                     <strong>{senderName}</strong>
                   </div>
-                  <time className="sender-date">
+                  <time className="sender-date montserrat">
                     {getDateTimeFormat(new Date().getTime())}
                   </time>
                 </div>

--- a/src/components/features/LetterWrite/InputRecipient/Forms/SituationForm.tsx
+++ b/src/components/features/LetterWrite/InputRecipient/Forms/SituationForm.tsx
@@ -57,7 +57,11 @@ const SituationForm = (): ReactElement => {
           {situationTemplatesData.map((template) => (
             <S.LetterWriteSituationSliderItem key={template.situationId}>
               <div>
-                <Image alt={template.title} {...template.situationImage} />
+                <Image
+                  alt={template.title}
+                  {...template.situationImage}
+                  priority
+                />
               </div>
               <SituationTag templateType={template.title} height={22} />
               <p>{template.description}</p>

--- a/src/components/features/LetterWrite/InputRecipient/styled.ts
+++ b/src/components/features/LetterWrite/InputRecipient/styled.ts
@@ -152,7 +152,9 @@ const LetterWriteSituationSliderItem = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  padding: 0 6px;
+  word-break: keep-all;
+  padding: 0 16px;
+
   & > div:first-of-type {
     height: 187px;
     display: flex;

--- a/src/components/features/LetterWrite/Main/styled.ts
+++ b/src/components/features/LetterWrite/Main/styled.ts
@@ -148,6 +148,7 @@ const GuidelineMainWrapper = styled.div<{ isListHeightChanged: boolean }>`
         width: inherit;
         background-color: ${({ theme }) => theme.colors.navy30};
         border-radius: ${({ theme }) => theme.radius.md};
+        text-align: left;
       }
     }
   }
@@ -282,7 +283,6 @@ const EmptyRemindContainer = styled.div`
   align-items: center;
   gap: 8px;
   height: 292px;
-  background-color: ${({ theme }) => theme.colors.navy50};
   border-radius: ${({ theme }) => theme.radius.md};
 
   span {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,6 +10,16 @@ class MyDocument extends Document {
             as="style"
             href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard-dynamic-subset.css"
           />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin=""
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+            rel="stylesheet"
+          />
           <script
             defer
             src="https://developers.kakao.com/sdk/js/kakao.min.js"

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -139,4 +139,8 @@ export const global = (theme: Theme) => css`
     font-weight: 700;
     font-style: normal;
   }
+
+  .montserrat {
+    font-family: "Montserrat";
+  }
 `;


### PR DESCRIPTION
* 🐛 웰컴팝업 QA 처리

- modal radius
- background 딤처리
- modal 하단 padding

* 🐛 메인화면 이미지 배열 조정

- 메인 로고 부분과 간격 조절

* 🐛 토스트 메시지 변경

- 토스트 메시지 하단 여백 최대값 기준 좌우 여백으로 변경
- 토스트 메시지 3초뒤 삭제
- 로그인 성공/실패 문구 변경

* 🐛 상황 설명 단어 단위로 개행

* 🐛 꼬깃 가이드 문장 왼쪽 정렬

* 🐛 꼬깃메모 empty 배경색상 제거

* 🐛 꼬깃 커버 부분 폰트 및 로딩시간

- 폰트 변경
- 로딩 기존 3000ms -> 1500mx 변경

* 🐛 토스트 디자인 변경

- 좌우 여백 20px 하단 여백 20px

* 🐛 토스트 메시지 3초 재 추가

* 🐛 사파리 이미지 아웃라인 및 상황태그 간격문제

* 🐛  웰컴팝업 이미지 엑박 해결